### PR TITLE
fix: use array instead of Vec for Codon representation (and other free perf improvements)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ serde = { version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 indexmap = { version = "2", features = ["serde"] }
 biocommons-bioutils = "0.1.0"
+ahash = "0.8.11"
 
 [dev-dependencies]
 anyhow = "1.0"


### PR DESCRIPTION
- use `[u8; 3]` instead of `Vec`, i.e. stack vs heap
- use ahash instead of fxhash
- use array slicing `&c[..3]` instead of `iter().take(3)` (even though that should not really have made a difference, but according to criterion, seemed to be the case)
- make translate a little more readable with or_else chaining