### PR TITLE
chore: Use the repository instead of the homepage field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Manuel Holtgrewe <manuel.holtgrewe@bih-charite.de>"]
 description = "Port of biocommons/hgvs to Rust"
 license = "Apache-2.0"
-homepage = "https://github.com/varfish-org/hgvs-rs"
+repository = "https://github.com/varfish-org/hgvs-rs"
 readme = "README.md"
 rust-version = "1.64.0"
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated project metadata by replacing the `homepage` field with a `repository` field in the package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->