### PR TITLE
fix: Fix incorrect seleno cds end

### DIFF
--- a/src/mapper/altseq.rs
+++ b/src/mapper/altseq.rs
@@ -1093,7 +1093,7 @@ impl AltSeqToHgvsp {
         is_init_met: bool,
         is_frameshift: bool,
     ) -> Result<HgvsVariant, Error> {
-        assert!(start.is_some() == end.is_some());
+        assert_eq!(start.is_some(), end.is_some());
 
         // If the `alternative` contains a stop codon (`*`/`X`) then we have to truncate
         // after it.


### PR DESCRIPTION
In selenoprotein cases, the `cds_end` obtained from (cdot) exon alignments can be incorrect, if the upstream information is incorrect.
"Guess" the actual `cds_end` by translating (with UGA → Sec) and finding the first non-sec stop codon in the translated sequence.