### PR TITLE
chore: Update rust CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -72,6 +72,9 @@ jobs:
         with:
           lfs: 'true'
 
+      - name: Install host libraries
+        run: sudo apt-get install -y libsqlite3-dev libsqlite3-0
+
       - name: Import test database.
         run: |
           set -euo pipefail

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,15 +16,11 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: rustfmt
+        uses: dtolnay/rust-toolchain@stable
+        components: rustfmt
 
       - name: Check format
-        run: |
-          cargo fmt -- --check
+        run: cargo fmt --check
 
   Linting:
     runs-on: ubuntu-latest
@@ -35,19 +31,14 @@ jobs:
           lfs: true
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          override: true
-          components: clippy
+        uses: dtolnay/rust-toolchain@stable
+        components: clippy
 
       - name: Lint with clippy
-        uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: cargo clippy --no-deps  # --all-targets --all-features
 
   Testing:
-    needs: Formatting
+    needs: [Formatting, Linting]
     runs-on: ubuntu-latest
 
     strategy:
@@ -89,18 +80,14 @@ jobs:
           PGPASSWORD: uta_admin
 
       - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@stable
         with:
-          toolchain: stable
-          override: true
+          components: llvm-tools-preview  # needed for cargo llvm-cov
 
       - uses: Swatinem/rust-cache@v2.7.3
 
-      - name: Run cargo-tarpaulin with fast tests
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: 0.21.0
-          args: "-- --test-threads 1"
+      - name: Run cargo-llvm-cov with fast tests
+        run: cargo llvm-cov -- --test-threads 1
         env:
           TEST_UTA_DATABASE_URL: postgres://uta_admin:uta_admin@0.0.0.0/uta
           TEST_UTA_DATABASE_SCHEMA: uta_20210129
@@ -109,10 +96,7 @@ jobs:
         if: ${{ matrix.label == 'fast' }}
 
       - name: Run cargo-test with full tests
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: "--release -- --include-ignored"
+        run: "cargo test --release -- --include-ignored"
         env:
           TEST_UTA_DATABASE_URL: postgres://uta_admin:uta_admin@0.0.0.0/uta
           TEST_UTA_DATABASE_SCHEMA: uta_20210129

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -17,7 +17,8 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
-        components: rustfmt
+        with:
+          components: rustfmt
 
       - name: Check format
         run: cargo fmt --check
@@ -32,7 +33,8 @@ jobs:
 
       - name: Install stable toolchain
         uses: dtolnay/rust-toolchain@stable
-        components: clippy
+        with:
+          components: clippy
 
       - name: Lint with clippy
         run: cargo clippy --no-deps  # --all-targets --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -88,6 +88,9 @@ jobs:
 
       - uses: Swatinem/rust-cache@v2.7.3
 
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+
       - name: Run cargo-llvm-cov with fast tests
         run: cargo llvm-cov --lcov --output-path lcov.info -- --test-threads 1
         env:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -87,7 +87,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.3
 
       - name: Run cargo-llvm-cov with fast tests
-        run: cargo llvm-cov -- --test-threads 1
+        run: cargo llvm-cov --lcov --output-path lcov.info -- --test-threads 1
         env:
           TEST_UTA_DATABASE_URL: postgres://uta_admin:uta_admin@0.0.0.0/uta
           TEST_UTA_DATABASE_SCHEMA: uta_20210129


### PR DESCRIPTION
Update actions used in the rust CI, switch from tarpaulin to cargo-llvm-cov

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow for Rust to streamline the CI process.
	- Simplified toolchain installation and linting configurations.
	- Enhanced control flow by requiring formatting and linting checks before running tests.
	- Transitioned to direct command usage for testing and coverage collection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->