### PR TITLE
fix: Produce Ident protein edits

### DIFF
--- a/src/mapper/altseq.rs
+++ b/src/mapper/altseq.rs
@@ -1111,10 +1111,18 @@ impl AltSeqToHgvsp {
             // of protein prediction is certain or uncertain by a global configuration
             // variable.
             ProtLocEdit::Ordinary {
-                loc: Mu::Certain(interval),
                 edit: Mu::Certain(if is_sub {
-                    ProteinEdit::Subst {
-                        alternative: alternative.to_string(),
+                    // cases like Ter525Ter should be Ter525=
+                    if reference == alternative
+                        || alternative.len() == 1
+                            && interval.start.aa == alternative
+                            && interval.start.number == interval.end.number
+                    {
+                        ProteinEdit::Ident
+                    } else {
+                        ProteinEdit::Subst {
+                            alternative: alternative.to_string(),
+                        }
                     }
                 } else if is_ext {
                     ProteinEdit::Ext {
@@ -1147,6 +1155,7 @@ impl AltSeqToHgvsp {
                         alternative: alternative.to_string(),
                     }
                 }),
+                loc: Mu::Certain(interval),
             }
         };
 

--- a/src/mapper/altseq.rs
+++ b/src/mapper/altseq.rs
@@ -295,21 +295,21 @@ impl AltSeqBuilder {
             | VariantLocation::FivePrimeUtr
             | VariantLocation::ThreePrimeUtr => EditType::NotCds,
             VariantLocation::WholeGene => match na_edit {
-                NaEdit::DelRef {..} |
+                NaEdit::DelRef { .. } |
                 NaEdit::DelNum { .. } => EditType::WholeGeneDeleted,
                 NaEdit::Dup { .. } => {
                     log::warn!("Whole-gene duplication; consequence assumed to not affect protein product");
                     EditType::NotCds
-                },
+                }
                 NaEdit::InvRef { .. } |
                 NaEdit::InvNum { .. } => {
                     log::warn!("Whole-gene inversion; consequence assumed to not affected protein product");
                     EditType::NotCds
-                },
-                NaEdit::RefAlt {.. } => {
+                }
+                NaEdit::RefAlt { .. } => {
                     log::warn!("The whole-gene variant {} is not a clean deletion. Assuming whole gene deletion.", self.var_c);
                     EditType::WholeGeneDeleted
-                },
+                }
                 _ => panic!("Invalid combination of whole gene variant location and NaEdit {na_edit:?}"),
             },
         };


### PR DESCRIPTION
In substitution cases where the reference and alternative are identical, produce an `Ident` variant, not a `Subst`.
Special handling is done for synonymous changes to the terminal, as in that case the reference is empty but the alternative is "*".