### PR TITLE
feat: Renormalize during `g_to_n` if `renormalize_g` is set to true

### DIFF
--- a/src/data/cdot/json.rs
+++ b/src/data/cdot/json.rs
@@ -1332,6 +1332,7 @@ pub mod tests {
         let config = assembly::Config {
             assembly: Assembly::Grch37,
             normalize,
+            renormalize_g: false,
             ..Default::default()
         };
         Ok(Mapper::new(config, provider))

--- a/src/mapper/assembly.rs
+++ b/src/mapper/assembly.rs
@@ -391,6 +391,7 @@ mod test {
         let config = Config {
             assembly: Assembly::Grch38,
             normalize,
+            renormalize_g: false,
             ..Config::default()
         };
         Ok(Mapper::new(config, provider))
@@ -401,6 +402,7 @@ mod test {
         let config = Config {
             assembly: Assembly::Grch37,
             normalize,
+            renormalize_g: false,
             ..Config::default()
         };
         Ok(Mapper::new(config, provider))

--- a/src/mapper/assembly.rs
+++ b/src/mapper/assembly.rs
@@ -41,8 +41,8 @@ pub struct Config {
     pub strict_validation: bool,
     pub strict_bounds: bool,
     pub add_gene_symbol: bool,
-    /// Re-normalize out of bounds genome variants on minus strand.  This can be
-    /// switched off so genome sequence does not have to be available in provider.
+    /// Always re-normalize genome variants during g-to-n projections.
+    /// This can be switched off so genome sequence does not have to be available in provider.
     pub renormalize_g: bool,
     /// Use the genome sequence in case of uncertain g-to-n projections.  This
     /// can be switched off so genome sequence does not have to be available.

--- a/src/mapper/variant.rs
+++ b/src/mapper/variant.rs
@@ -1026,7 +1026,10 @@ mod test {
 
     fn build_mapper() -> Result<Mapper, Error> {
         let provider = build_provider()?;
-        let config = Config::default();
+        let config = Config {
+            renormalize_g: false,
+            ..Default::default()
+        };
         Ok(Mapper::new(&config, provider))
     }
 
@@ -1365,6 +1368,7 @@ mod test {
             let provider = Arc::new(Provider::new(&path)?);
             let config = Config {
                 strict_bounds,
+                renormalize_g: false,
                 ..Default::default()
             };
             Ok(Mapper::new(&config, provider))

--- a/src/mapper/variant.rs
+++ b/src/mapper/variant.rs
@@ -198,7 +198,7 @@ impl Mapper {
             var_g.clone()
         };
 
-        let var_g = if self.config.renormalize_g {
+        let var_g = if self.config.renormalize_g && self.config.genome_seq_available {
             self.normalizer()?.normalize(&var_g)?
         } else {
             var_g.clone()

--- a/src/mapper/variant.rs
+++ b/src/mapper/variant.rs
@@ -5,7 +5,7 @@ use std::{ops::Range, sync::Arc};
 
 use cached::proc_macro::cached;
 use cached::SizedCache;
-use log::{debug, info};
+use log::debug;
 
 use crate::{
     data::interface::Provider,

--- a/src/mapper/variant.rs
+++ b/src/mapper/variant.rs
@@ -197,6 +197,13 @@ impl Mapper {
         } else {
             var_g.clone()
         };
+
+        let var_g = if self.config.renormalize_g {
+            self.normalizer()?.normalize(&var_g)?
+        } else {
+            var_g.clone()
+        };
+
         if let HgvsVariant::GenomeVariant {
             accession,
             loc_edit,
@@ -204,18 +211,6 @@ impl Mapper {
         } = &var_g
         {
             let mapper = self.build_alignment_mapper(tx_ac, &accession.value, alt_aln_method)?;
-
-            let var_g = if mapper.strand == -1
-                && !self.config.strict_bounds
-                && !mapper.is_g_interval_in_bounds(loc_edit.loc.inner())
-                && self.config.renormalize_g
-            {
-                info!("Renormalizing out-of-bounds minus strand variant on genomic sequenc");
-                self.normalizer()?.normalize(&var_g)?
-            } else {
-                var_g.clone()
-            };
-
             let pos_n = mapper.g_to_n(loc_edit.loc.inner())?;
             let pos_n = Mu::from(
                 pos_n.inner(),


### PR DESCRIPTION
This PR introduces a change which deviates from biocommons hgvs:
`var_g` is always normalized if `renormalize_g` is enabled (which requires reference sequences to be available in the provider), not only for out-of-bounds variants on the minus strand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified the description of a configuration setting to accurately reflect its role in consistently applying genome variant normalization.

- **Refactor**
  - Streamlined the variant processing logic by consolidating condition checks for normalization during genome-to-network projections, resulting in cleaner and more predictable behavior. 
  - Removed outdated logic for handling out-of-bounds conditions in genome variants.

- **Bug Fixes**
  - Adjusted the default behavior of the `renormalize_g` setting in test cases to disable re-normalization during mapper initialization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->