### PR TITLE
fix: introduce clamping to mimick hgvs python behaviour

### DIFF
--- a/src/mapper/altseq.rs
+++ b/src/mapper/altseq.rs
@@ -449,17 +449,28 @@ impl AltSeqBuilder {
 
         // Incorporate the variant into the sequence (depending on the type).
         let mut is_substitution = false;
+        let range = if end >= seq.len() && reference.is_some() {
+            log::warn!(
+                    "Altered sequence range {:?} is incompatible with sequence length {:?}, clamping. Variant description is {}",
+                    start..end,
+                    seq.len(),
+                    &self.var_c
+                );
+            start..seq.len()
+        } else {
+            start..end
+        };
         match (reference, alternative) {
             (Some(reference), Some(alternative)) => {
                 // delins or SNP
-                seq.replace_range(start..end, &alternative);
+                seq.replace_range(range, &alternative);
                 if reference.len() == 1 && alternative.len() == 1 {
                     is_substitution = true;
                 }
             }
             (Some(_reference), None) => {
                 // deletion
-                seq.replace_range(start..end, "");
+                seq.replace_range(range, "");
             }
             (None, Some(alternative)) => {
                 // insertion

--- a/src/mapper/assembly.rs
+++ b/src/mapper/assembly.rs
@@ -281,7 +281,7 @@ impl Mapper {
     /// Normalize variant if requested and ignore errors.  This is better than checking whether
     /// the variant is intronic because future UTAs will support LRG, which will enable checking
     /// intronic variants.
-    fn maybe_normalize(&self, var: &HgvsVariant) -> Result<HgvsVariant, Error> {
+    pub fn maybe_normalize(&self, var: &HgvsVariant) -> Result<HgvsVariant, Error> {
         if self.config.normalize {
             let normalizer = self.inner.normalizer()?;
             normalizer.normalize(var).or_else(|_| {

--- a/src/mapper/variant.rs
+++ b/src/mapper/variant.rs
@@ -7,6 +7,7 @@ use cached::proc_macro::cached;
 use cached::SizedCache;
 use log::debug;
 
+use crate::mapper::alignment;
 use crate::{
     data::interface::Provider,
     mapper::Error,

--- a/src/mapper/variant.rs
+++ b/src/mapper/variant.rs
@@ -19,8 +19,6 @@ use crate::{
     validator::{ValidationLevel, Validator},
 };
 
-use super::alignment;
-
 /// Configuration for Mapper.
 ///
 /// Defaults are taken from `hgvs` Python library.
@@ -250,7 +248,7 @@ impl Mapper {
                     (Mu::Certain((*pos_n).clone()), edit_n)
                 }
             } else {
-                // This is the how the original code handles uncertain positions.  We will reach
+                // This is how the original code handles uncertain positions.  We will reach
                 // here if the position is uncertain and we have the genome sequence.
                 let pos_g = mapper.n_to_g(pos_n)?;
                 let edit_n = NaEdit::RefAlt {
@@ -781,6 +779,17 @@ impl Mapper {
             .loc_range()
             .ok_or(Error::NoAlteredSequenceForMissingPositions)?;
         let r = ((r.start - interval.start) as usize)..((r.end - interval.start) as usize);
+        let r = if r.end >= seq.len() {
+            log::warn!(
+                    "Altered sequence range {:?} is incompatible with sequence length {:?}, clamping. Variant description is {}",
+                    r,
+                    seq.len(),
+                    &var
+                );
+            r.start..seq.len()
+        } else {
+            r
+        };
 
         let na_edit = var.na_edit().ok_or(Error::NaEditMissing)?;
 
@@ -788,7 +797,11 @@ impl Mapper {
             NaEdit::RefAlt { alternative, .. } | NaEdit::NumAlt { alternative, .. } => {
                 seq.replace_range(r, alternative)
             }
-            NaEdit::DelRef { .. } | NaEdit::DelNum { .. } => seq.replace_range(r, ""),
+            NaEdit::DelRef { .. } | NaEdit::DelNum { .. } => {
+                // FIXME the original code in python simply does `del seq[pos_start:pos_end]`,
+                //  which does not error if `pos_end > len(seq)`. Check if this is intended or not.
+                seq.replace_range(r, "")
+            }
             NaEdit::Ins { alternative } => {
                 seq.replace_range((r.start + 1)..(r.start + 1), alternative)
             }


### PR DESCRIPTION
In biocommons hgvs, deleting sequences happens via python's del, e.g.: `del seq[start:end]`.
However, if the range is out of bounds for the underlying sequence, this will happily remove just what's there and silently continue. In other words, if `end > len(seq)` , this is equivalent to `del seq[start:]`.
In the rust version we make use of `replace_range`, which does perform bounds checks.

I suspect that the underlying issue is some incorrect logic / missing update earlier in the process which results in a mismatch between the interval specified and the variant/position/edit description.
But for now, I'll simply mimick the behaviour.

Example variant for which this happens:
5:150375001:TGCCAAGGAGTCCCCCAGGAAAGG:T (or NC_000005.10:g.150375003_150375025del _after normalization_)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved handling of sequence modifications by automatically clamping ranges that exceed available sequence length and issuing warnings to prevent runtime errors.
	- Enhanced variant mapping to ensure deletion and insertion operations remain within valid sequence bounds.
- **New Features**
	- Made variant normalization externally accessible, enabling enhanced variant processing for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->