### PR TITLE
fix: report deletions that end right before the stop codon as deletions, not as Ter substitutions

### DIFF
--- a/src/mapper/altseq.rs
+++ b/src/mapper/altseq.rs
@@ -989,29 +989,20 @@ impl AltSeqToHgvsp {
                 };
                 alternative.clone_from(insertion);
             } else {
-                // deletion OR stop codon at variant position
-                if deletion.len() as i32 + start == self.ref_seq().len() as i32 {
-                    // stop codon at variant position
-                    aa_end = aa_start.clone();
-                    reference = "".to_string();
-                    alternative = "*".to_string();
-                    is_sub = true;
+                // deletion
+                aa_end = if end > *start {
+                    Some(ProtPos {
+                        aa: deletion
+                            .chars()
+                            .last()
+                            .ok_or(Error::DeletionSequenceEmpty)?
+                            .to_string(),
+                        number: end,
+                    })
                 } else {
-                    // deletion
-                    aa_end = if end > *start {
-                        Some(ProtPos {
-                            aa: deletion
-                                .chars()
-                                .last()
-                                .ok_or(Error::DeletionSequenceEmpty)?
-                                .to_string(),
-                            number: end,
-                        })
-                    } else {
-                        aa_start.clone()
-                    };
-                    alternative = "".to_string()
-                }
+                    aa_start.clone()
+                };
+                alternative = "".to_string()
             }
         } else if deletion.is_empty() {
             // insertion OR duplication OR extension

--- a/src/mapper/altseq.rs
+++ b/src/mapper/altseq.rs
@@ -40,7 +40,7 @@ pub struct RefTranscriptData {
                        tx_ac,
                        pro_ac) }"#
 )]
-pub(crate) fn ref_transcript_data_cached(
+pub fn ref_transcript_data_cached(
     provider: Arc<dyn Provider + Send + Sync>,
     tx_ac: &str,
     pro_ac: Option<&str>,
@@ -114,29 +114,29 @@ impl RefTranscriptData {
 pub struct AltTranscriptData {
     /// Transcript nucleotide sequence.
     #[allow(dead_code)]
-    transcript_sequence: String,
+    pub transcript_sequence: String,
     /// 1-letter amino acid sequence.
-    aa_sequence: String,
+    pub aa_sequence: String,
     /// 1-based CDS start position.
     #[allow(dead_code)]
-    cds_start: i32,
+    pub cds_start: i32,
     /// 1-based CDS stop position.
     #[allow(dead_code)]
-    cds_stop: i32,
+    pub cds_stop: i32,
     /// Protein accession number, e.g., `"NP_999999.2"`.
     #[allow(dead_code)]
-    protein_accession: String,
+    pub protein_accession: String,
     /// Whether this is a frameshift variant.
-    is_frameshift: bool,
+    pub is_frameshift: bool,
     /// 1-based AA start index for this variant.
-    variant_start_aa: Option<i32>,
+    pub variant_start_aa: Option<i32>,
     /// Starting position (AA ref index) of the last framewshift which affects the rest of the
     /// sequence, ie.e., not offset by subsequent frameshifts.
-    frameshift_start: Option<i32>,
+    pub frameshift_start: Option<i32>,
     /// Whether this is a substitution AA variant.
-    is_substitution: bool,
+    pub is_substitution: bool,
     /// Whether variant is "?".
-    is_ambiguous: bool,
+    pub is_ambiguous: bool,
 }
 
 impl AltTranscriptData {
@@ -1093,7 +1093,7 @@ impl AltSeqToHgvsp {
         is_init_met: bool,
         is_frameshift: bool,
     ) -> Result<HgvsVariant, Error> {
-        assert!(start.is_some() == end.is_some());
+        assert_eq!(start.is_some(), end.is_some());
 
         // If the `alternative` contains a stop codon (`*`/`X`) then we have to truncate
         // after it.

--- a/src/mapper/mod.rs
+++ b/src/mapper/mod.rs
@@ -1,7 +1,7 @@
 //! Code supporting mapping between coordinate systems.
 
 pub mod alignment;
-pub(crate) mod altseq;
+pub mod altseq;
 pub mod assembly;
 pub mod cigar;
 mod error;


### PR DESCRIPTION
_I am unsure on how to interpret the HGVS nomenclature guideline in cases where there is a deletion that ends right before the stop codon. Needs discussion._