### PR TITLE
feat: add support for arbitrary tags

### DIFF
--- a/src/data/cdot/json.rs
+++ b/src/data/cdot/json.rs
@@ -201,7 +201,7 @@ pub mod models {
     }
 
     /// Enum for representing the tags for transcripts.
-    #[derive(Deserialize, Serialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    #[derive(Deserialize, Serialize, Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
     pub enum Tag {
         Basic,
         EnsemblCanonical,
@@ -209,7 +209,7 @@ pub mod models {
         ManePlusClinical,
         RefSeqSelect,
         GencodePrimary,
-        Other,
+        Other(String),
     }
 
     #[derive(Deserialize, Serialize, Debug, Clone)]
@@ -538,7 +538,7 @@ pub mod models {
             "GENCODE Primary" => Tag::GencodePrimary,
             _ => {
                 log::trace!("unknown tag: {}", s);
-                Tag::Other
+                Tag::Other(s.to_string())
             }
         }
     }


### PR DESCRIPTION
Because CDOT json files (or rather the gtfs/gffs they're based on) will have more than what we have atm, we now capture anything that we haven't seen yet in the `Other(String)` variant.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Unknown transcript tags are now preserved and displayed as part of the tag information.

- **Bug Fixes**
  - Improved handling of unrecognized tags to ensure they are not lost or omitted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->