### PR TITLE
feat: support non-coding transcripts (NR_) in TxIdentityInfo

### DIFF
--- a/src/data/cdot/json.rs
+++ b/src/data/cdot/json.rs
@@ -1025,8 +1025,11 @@ impl TxProvider {
             tx_ac: tx_ac.to_string(),
             alt_ac: tx_ac.to_string(), // sic(!)
             alt_aln_method: String::from("transcript"),
-            cds_start_i: tx.start_codon.unwrap_or_default(),
-            cds_end_i: tx.stop_codon.unwrap_or_default(),
+            // Pass through Option values directly; previously these used
+            // unwrap_or_default() which silently mapped non-coding transcripts
+            // (NR_*) to cds position 0.
+            cds_start_i: tx.start_codon,
+            cds_end_i: tx.stop_codon,
             lengths,
             hgnc,
             translation_table: if is_selenoprotein {

--- a/src/data/interface.rs
+++ b/src/data/interface.rs
@@ -131,17 +131,28 @@ pub struct TxForRegionRecord {
 /// lengths        | {707,79,410}
 /// hgnc           | VSX1
 /// ```
+///
+/// For non-coding transcripts (e.g., NR_*), `cds_start_i` and `cds_end_i` are `None`.
 #[derive(Debug, PartialEq, Default, Clone)]
 pub struct TxIdentityInfo {
     pub tx_ac: String,
     pub alt_ac: String,
     pub alt_aln_method: String,
-    pub cds_start_i: i32,
-    pub cds_end_i: i32,
+    /// CDS start position (0-based); `None` for non-coding transcripts.
+    pub cds_start_i: Option<i32>,
+    /// CDS end position (0-based); `None` for non-coding transcripts.
+    pub cds_end_i: Option<i32>,
     pub lengths: Vec<i32>,
     pub hgnc: String,
     /// The translation table to use for this transcript.
     pub translation_table: TranslationTable,
+}
+
+impl TxIdentityInfo {
+    /// Returns `true` if both `cds_start_i` and `cds_end_i` are defined.
+    pub fn has_cds_defined(&self) -> bool {
+        self.cds_start_i.is_some() && self.cds_end_i.is_some()
+    }
 }
 
 /// ```text

--- a/src/data/uta.rs
+++ b/src/data/uta.rs
@@ -813,7 +813,7 @@ mod test {
         assert_eq!(
             format!("{:?}", &record),
             "TxIdentityInfo { tx_ac: \"ENST00000421528\", alt_ac: \"ENST00000421528\", \
-            alt_aln_method: \"transcript\", cds_start_i: 0, cds_end_i: 985, lengths: \
+            alt_aln_method: \"transcript\", cds_start_i: Some(0), cds_end_i: Some(985), lengths: \
             [24, 229, 174, 108, 129, 75, 150, 143, 1073], hgnc: \"OMA1\", translation_table: \
             Standard }",
         );

--- a/src/mapper/alignment.rs
+++ b/src/mapper/alignment.rs
@@ -217,8 +217,8 @@ impl Mapper {
             (
                 1, // strand
                 0, // gc_offset
-                Some(cds_start_i),
-                Some(cds_end_i),
+                cds_start_i,
+                cds_end_i,
                 tgt_len,
                 Default::default(),
             )

--- a/src/mapper/altseq.rs
+++ b/src/mapper/altseq.rs
@@ -64,9 +64,15 @@ impl RefTranscriptData {
         let tx_info = provider.as_ref().get_tx_identity_info(tx_ac)?;
         let transcript_sequence = provider.as_ref().get_seq(tx_ac)?;
 
+        // Non-coding transcripts (e.g., NR_*) don't have a CDS defined.
+        let (cds_start_i, cds_end_i) = match (tx_info.cds_start_i, tx_info.cds_end_i) {
+            (Some(start), Some(end)) => (start, end),
+            _ => return Err(Error::CdsUndefined(tx_ac.to_string())),
+        };
+
         // Use 1-based HGVS coordinates.
-        let cds_start = tx_info.cds_start_i + 1;
-        let cds_stop = tx_info.cds_end_i;
+        let cds_start = cds_start_i + 1;
+        let cds_stop = cds_end_i;
 
         // Coding sequences that are not divisable by 3 are not yet supported.
         let tx_seq_to_translate =

--- a/src/mapper/variant.rs
+++ b/src/mapper/variant.rs
@@ -1409,8 +1409,8 @@ mod test {
                             tx_ac: record.accession.clone(),
                             alt_ac: record.accession.clone(),
                             alt_aln_method: "splign".to_string(),
-                            cds_start_i: record.cds_start_i,
-                            cds_end_i: record.cds_end_i,
+                            cds_start_i: Some(record.cds_start_i),
+                            cds_end_i: Some(record.cds_end_i),
                             lengths: Vec::new(),
                             hgnc: "MOCK".to_string(),
                             ..Default::default()


### PR DESCRIPTION
## Summary

Non-coding transcripts (NR_*) don't have CDS (coding sequence) regions, so `cds_start_i` and `cds_end_i` are NULL in the UTA database. Previously, the `TxIdentityInfo` struct expected these as non-optional `i32` values, causing a `WasNull` error when querying NR_ transcripts.

This PR makes `cds_start_i` and `cds_end_i` optional in `TxIdentityInfo`, enabling normalization of non-coding transcript variants like `NR_024540.1:n.100T>G`.

## Changes

- `TxIdentityInfo.cds_start_i` and `cds_end_i` are now `Option<i32>`
- Added `TxIdentityInfo::is_coding()` helper method
- `RefTranscriptData::new()` returns `CdsUndefined` error for non-coding transcripts (protein translation doesn't apply to them)
- Updated cdot json provider to pass through Option values
- Updated alignment mapper to handle Option fields
- Updated test mock and expected output format

## Testing

Verified that NR_ transcripts now normalize successfully:

```
--- Testing: NR_024540.1:n.100T>G ---
Parsed: NR_024540.1:n.100T>G
Normalized: NR_024540.1:n.100T>G
```

## Breaking Change

This is a breaking API change - code that accesses `TxIdentityInfo.cds_start_i` or `cds_end_i` will need to handle the `Option` type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * CDS endpoints for non-coding transcripts are now preserved as undefined instead of defaulting to zero, improving transcript handling and accuracy.
  * Operations that require CDS now fail early with clearer errors when CDS is undefined.

* **New Features**
  * Added a utility to identify whether a transcript has CDS defined.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->