### PR TITLE
feat: derive Serialize/Deserialize for Provider record types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/lib.rs"
 [dependencies]
 base16ct = "1.0"
 bio = "3.0"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 flate2 = "1.0"
 log = "0.4"
 md-5 = "0.10"

--- a/src/data/interface.rs
+++ b/src/data/interface.rs
@@ -2,6 +2,7 @@
 
 use chrono::NaiveDateTime;
 use indexmap::IndexMap;
+use serde::{Deserialize, Serialize};
 
 use crate::{data::error::Error, sequences::TranslationTable};
 use biocommons_bioutils::assemblies::Assembly;
@@ -16,7 +17,7 @@ use biocommons_bioutils::assemblies::Assembly;
 /// aliases | AT1,ATA,ATC,ATD,ATE,ATDC,TEL1,TELO1
 /// added   | 2014-02-04 21:39:32.57125
 /// ```
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct GeneInfoRecord {
     pub hgnc: String,
     pub maploc: String,
@@ -45,7 +46,7 @@ pub struct GeneInfoRecord {
 /// structure means that the transcripts are defined on the same
 /// reference sequence and have the same exon spans on that
 /// sequence.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct TxSimilarityRecord {
     /// Accession of first transcript.
     pub tx_ac1: String,
@@ -82,7 +83,7 @@ pub struct TxSimilarityRecord {
 /// alt_exon_id     | 6063334
 /// exon_aln_id     | 3461425
 ///```
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct TxExonsRecord {
     pub hgnc: String,
     pub tx_ac: String,
@@ -112,7 +113,7 @@ pub struct TxExonsRecord {
 /// start_i        | 95226307
 /// end_i          | 95248406
 /// ```
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct TxForRegionRecord {
     pub tx_ac: String,
     pub alt_ac: String,
@@ -133,7 +134,7 @@ pub struct TxForRegionRecord {
 /// ```
 ///
 /// For non-coding transcripts (e.g., NR_*), `cds_start_i` and `cds_end_i` are `None`.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct TxIdentityInfo {
     pub tx_ac: String,
     pub alt_ac: String,
@@ -163,7 +164,7 @@ impl TxIdentityInfo {
 /// alt_ac         | AC_000143.1
 /// alt_aln_method | splign
 /// ```
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct TxInfoRecord {
     pub hgnc: String,
     pub cds_start_i: Option<i32>,
@@ -183,7 +184,7 @@ pub struct TxInfoRecord {
 /// alt_ac         | NC_000012.11
 /// alt_aln_method | genebuild
 /// ```
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct TxMappingOptionsRecord {
     pub tx_ac: String,
     pub alt_ac: String,


### PR DESCRIPTION
Adds `serde::Serialize` and `serde::Deserialize` derives to the seven record types in `data::interface`: `GeneInfoRecord`, `TxSimilarityRecord`, `TxExonsRecord`, `TxForRegionRecord`, `TxIdentityInfo`, `TxInfoRecord`, and `TxMappingOptionsRecord`. Also enables the `serde` feature on the existing `chrono` dependency for `NaiveDateTime` in `GeneInfoRecord`.

I'm working on an in-memory `Provider` for benchmarking in [ferro-hgvs](https://github.com/fulcrumgenomics/ferro-hgvs) and would like to serialize the provider data to a binary cache file (via bincode) to avoid re-querying PostgreSQL on every run. Serde derives on the record types make this straightforward. This may also be useful for other downstream consumers that want to cache or transmit provider data.

Since `serde` is already a required dependency of the crate, this doesn't add any new build cost. No breaking changes — all existing tests pass unchanged.

Happy to gate this behind an optional feature flag if preferred, or to extend the derives to other public types. Let me know what you think.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated data serialization capabilities and dependencies to enhance overall data handling and compatibility throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->