### PR TITLE
docs: clarify Provider selection for testing vs production use

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@
 This is a port of [biocommons/hgvs](https://github.com/biocommons/hgvs) to the Rust programming language.
 The `data::cdot::*` code is based on a port of  [SACGF/cdot](https://github.com/SACGF/cdot) to Rust.
 
+## Choosing a Provider
+
+The crate includes three `Provider` implementations for accessing transcript and sequence data:
+
+| Provider | Data Source | Best For |
+|---|---|---|
+| `data::uta::Provider` | PostgreSQL (UTA) | Testing, development |
+| `data::uta_sr::Provider` | PostgreSQL (UTA) + SeqRepo | Testing with genome contigs |
+| `data::cdot::json::Provider` | cDOT JSON + SeqRepo | Offline use without PostgreSQL |
+
+All three providers incur I/O overhead per query (database round-trips or filesystem access), which
+can dominate normalization throughput for high-volume workloads.
+
+For **production use**, consider implementing the `Provider` trait with an in-memory or
+purpose-built data store. Two examples of this approach:
+
+- [mehari](https://github.com/varfish-org/mehari) deserializes a protobuf-encoded transcript
+  database into memory and indexes it with interval trees, backed by RocksDB for sequence storage.
+- [ferro-hgvs](https://github.com/fulcrumgenomics/ferro-hgvs) uses indexed FASTA files with
+  cDOT metadata, supporting random access via FAI indexes and optional memory-mapped I/O.
+
 ## Running Tests
 
 The tests need an instance of UTA to run.


### PR DESCRIPTION
> Written by Claude Code, human reviewed by Nils Homer.

## Summary

- Add a "Choosing a Provider" section to the README describing the three built-in providers and their intended use cases
- Note that all built-in providers incur I/O overhead that can limit throughput for production workloads
- Point to mehari and ferro-hgvs as examples of custom in-memory/file-backed Provider implementations

Closes #265

## Test plan

- [ ] Verify README renders correctly on GitHub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on selecting and implementing Providers with information about underlying data sources, use cases, and per-query I/O performance implications.
  * Included recommendations for production environments regarding in-memory or specialized provider implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->